### PR TITLE
Add 'getContactList' definition in Client+Prospects+Supplier collections

### DIFF
--- a/definitions/Client.php
+++ b/definitions/Client.php
@@ -51,6 +51,7 @@ class Client implements DefinitionInterface
         $collection->registerMethod(new Method($collection, 'getOne'));
         $collection->registerMethod(new Method($collection, 'getAddress'));
         $collection->registerMethod(new Method($collection, 'getContact'));
+        $collection->registerMethod(new Method($collection, 'getContactList'));
         $collection->registerMethod(new Method($collection, 'create'));
         $collection->registerMethod(new Method($collection, 'update'));
         $collection->registerMethod(new Method($collection, 'delete'));

--- a/definitions/Prospects.php
+++ b/definitions/Prospects.php
@@ -55,6 +55,7 @@ class Prospects implements DefinitionInterface
         $collection->registerMethod(new Method($collection, 'updateOwner'));
         $collection->registerMethod(new Method($collection, 'getAddress'));
         $collection->registerMethod(new Method($collection, 'getContact'));
+        $collection->registerMethod(new Method($collection, 'getContactList'));
         $collection->registerMethod(new Method($collection, 'addAddress'));
         $collection->registerMethod(new Method($collection, 'addContact'));
         $collection->registerMethod(new Method($collection, 'updateAddress'));

--- a/definitions/Supplier.php
+++ b/definitions/Supplier.php
@@ -51,6 +51,7 @@ class Supplier implements DefinitionInterface
         $collection->registerMethod(new Method($collection, 'getOne'));
         $collection->registerMethod(new Method($collection, 'getAddress'));
         $collection->registerMethod(new Method($collection, 'getContact'));
+        $collection->registerMethod(new Method($collection, 'getContactList'));
         $collection->registerMethod(new Method($collection, 'create'));
         $collection->registerMethod(new Method($collection, 'update'));
         $collection->registerMethod(new Method($collection, 'delete'));


### PR DESCRIPTION
Add undocumented method `getContactList`, in multiple Collections (Client, Prospects, Supplier) who all need as params :

```php
$request = array(
    'method' => 'Client.getContactList', // Prospects.getContactList // Supplier.getContactList
    'params' => array (
        'clientid' => {{clientid}},
    ) 
);
```

Parameter | required | type | default | Description
------------ | ------------- | ------------- | ------------- | -------------
{{clientid}} | yes | int | none | Customer ID
