### PR TITLE
Fix "400 Bad request" on Document.create

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -184,9 +184,7 @@ class Client implements ClientInterface
             'oauth_signature' => $encodedKey,
         ];
 
-        $request = $request->withHeader('Authorization', $this->encodeOAuthHeaders($oauthParams));
-
-        return $request->withHeader('Expect', '');
+        return $request->withHeader('Authorization', $this->encodeOAuthHeaders($oauthParams));
     }
 
     private function getNewUri(): UriInterface


### PR DESCRIPTION
Hi,

I'm using this client to create documents on Sellsy but I receive a "400 Bad Request" response code.
```php
$client->Document()->create(['document' => [...], 'row' => [...]]])->getResponse();
```

I tried to use Postman to do the same request manually and it worked fine. So after some research I found that your client is sending a header `Expect` with no value whereas Postman don't.

So I propose to remove this header (this resolves the problem) or maybe to give it a correct value. (no tried)
See : https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect

Have a nice day! 🌞 