### PR TITLE
Support camel case convention

### DIFF
--- a/src/Sellsy.php
+++ b/src/Sellsy.php
@@ -157,7 +157,7 @@ class Sellsy
         }
 
         if (!class_exists($collectionName, true)) {
-            $collectionClassName = 'Teknoo\\Sellsy\\Definitions\\' . $collectionName;
+            $collectionClassName = 'Teknoo\\Sellsy\\Definitions\\' . ucfirst($collectionName);
 
             if (!class_exists($collectionClassName, true)) {
                 throw new DomainException("Error, the $collectionName has been not found");

--- a/tests/Sellsy/DefinitionsTest.php
+++ b/tests/Sellsy/DefinitionsTest.php
@@ -50,7 +50,7 @@ class DefinitionsTest extends \PHPUnit\Framework\TestCase
 
             $collectionName = \str_replace('.php', '', $collectionName);
 
-            $collectionClassName = 'Teknoo\\Sellsy\\Definitions\\'.$collectionName;
+            $collectionClassName = 'Teknoo\\Sellsy\\Definitions\\'.ucfirst($collectionName);
 
             if (!\class_exists($collectionClassName, true)) {
                 $this->fail(

--- a/tests/Sellsy/SellsyTest.php
+++ b/tests/Sellsy/SellsyTest.php
@@ -133,14 +133,21 @@ class SellsyTest extends \PHPUnit\Framework\TestCase
         $definitionDir = dirname(__DIR__).'/../definitions';
         foreach (scandir($definitionDir) as $item) {
             if ('.' != $item && '..' != $item) {
+                $def_name = str_replace('.php', '', $item);
+
                 self::assertInstanceOf(
                     CollectionInterface::class,
-                    $sellsy->{str_replace('.php', '', $item)}()
+                    $sellsy->{$def_name}()
                 );
 
                 self::assertInstanceOf(
                     CollectionInterface::class,
-                    $sellsy->{str_replace('.php', '', $item)}()
+                    $sellsy->{$def_name}()
+                );
+                
+                self::assertInstanceOf(
+                    CollectionInterface::class,
+                    $sellsy->{lcfirst($def_name)}()
                 );
             }
         }


### PR DESCRIPTION
Adding a ucfirst allow using camel case convention : 

```
$client->document()->methodName();
$client->bankDeposit()->methodName();
```