### PR TITLE
Add RateLimitTransport and its documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Simple Example
 How-to
 ------
 Quick How-to to learn how use this library : [Startup](docs/quick-startup.md).
+Manage Sellsy Rate Limiting : [Rate Limiting](docs/rate-limiting.md).
 
 Support this project
 ---------------------

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,25 @@
+#Teknoo Software - Sellsy client - Sellsy Rate Limiting
+
+##Introduction
+
+Sellsy API has a rate limiting system to prevent abuse of the API. As stated in the documentation, the limit is 5 requests per second.
+
+##Manage Rate Limiting
+
+To manage the rate limiting, a middleware `Transport` can be used to wait between each request to respect the limit:
+
+    ```php
+    // Create the middleware Transport
+    $transport = new RateLimitTransport($transportBridge);
+    // Set the transport bridge
+    $sellsy->setTransport($transport);
+    ```
+
+##Limits
+
+Use the middleware at your own risk: it can crash very quickly a webserver!
+
+In sleep/usleep, the PHP process is freeze and can not execute another stuff.
+The count of php process is limited on PHP-FPM.
+
+If an async behavior is used (like reactphp or fibers), sleep/usleep will block other requests / operations.

--- a/src/Transport/RateLimitTransport.php
+++ b/src/Transport/RateLimitTransport.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Sellsy Client.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license
+ * license that are bundled with this package in the folder licences
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to richarddeloge@gmail.com so we can send you a copy immediately.
+ *
+ *
+ * @copyright   Copyright (c) EIRL Richard Déloge (richarddeloge@gmail.com)
+ * @copyright   Copyright (c) SASU Teknoo Software (https://teknoo.software)
+ *
+ * @link        http://teknoo.software/sellsy-client Project website
+ *
+ * @license     http://teknoo.software/sellsy-client/license/mit         MIT License
+ * @author      Julien Herr <julien@herr.fr>
+ */
+
+declare(strict_types=1);
+
+namespace Teknoo\Sellsy\Transport;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+use function intval;
+use function microtime;
+use function usleep;
+
+/**
+ * Be careful: this class has a blocking behavior because it uses sleep
+ */
+class RateLimitTransport implements TransportInterface
+{
+    public const RATE_LIMIT = 5;
+
+    private TransportInterface $transport;
+    private int $rateLimit;
+    private int $cnt;
+    private float $time;
+
+    public function __construct(
+        TransportInterface $transport,
+        int $rateLimit = self::RATE_LIMIT
+    ) {
+        $this->transport = $transport;
+        $this->rateLimit = $rateLimit;
+        $this->cnt = 0;
+        $this->time = microtime(true);
+    }
+
+    public function createRequest(string $method, $uri): RequestInterface
+    {
+        return $this->transport->createRequest($method, $uri);
+    }
+
+    public function createStream(array &$elements, ?RequestInterface $request = null): StreamInterface
+    {
+        return $this->transport->createStream($elements, $request);
+    }
+
+    public function createUri(string $uri = ''): UriInterface
+    {
+        return $this->transport->createUri($uri);
+    }
+
+    public function asyncExecute(RequestInterface $request): PromiseInterface
+    {
+        $this->cnt++;
+        if ($this->cnt === $this->rateLimit) {
+            $stop = microtime(true);
+            $sleep = 1000000 - intval(($stop - $this->time) * 1000000);
+            if ($sleep > 0) {
+                usleep($sleep);
+            }
+            $this->time = microtime(true);
+            $this->cnt = 0;
+        }
+        return $this->transport->asyncExecute($request);
+    }
+}

--- a/tests/Sellsy/Transport/RateLimitTransportTest.php
+++ b/tests/Sellsy/Transport/RateLimitTransportTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace Teknoo\Tests\Sellsy\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+use Teknoo\Sellsy\Transport\RateLimitTransport;
+use Teknoo\Sellsy\Transport\TransportInterface;
+use function microtime;
+
+class RateLimitTransportTest extends TestCase
+{
+    public function testWithoutLimit(): void
+    {
+        $transport = $this->createMock(TransportInterface::class);
+        $request = $this->createMock(RequestInterface::class);
+        $before = microtime(true);
+        for ($i = 1; $i <= 10; $i++) {
+            $transport->asyncExecute($request);
+        }
+        $after = microtime(true);
+        self::assertLessThan(1., $after - $before);
+    }
+
+    public function testWithLimit(): void
+    {
+        $transport = $this->createMock(TransportInterface::class);
+        $transport = new RateLimitTransport($transport);
+
+        $request = $this->createMock(RequestInterface::class);
+        $before = microtime(true);
+        for ($i = 1; $i <= 10; $i++) {
+            $transport->asyncExecute($request);
+        }
+        $after = microtime(true);
+        self::assertGreaterThan(1., $after - $before);
+    }
+
+    public function testCreateUri(): void
+    {
+        $mock = $this->createMock(TransportInterface::class);
+        $result = $this->createMock(UriInterface::class);
+        $mock->expects(self::once())
+            ->method('createUri')
+            ->with('uri')
+            ->will(self::returnValue($result));
+
+        $transport = new RateLimitTransport($mock);
+        $uri = $transport->createUri('uri');
+        self::assertEquals($result, $uri);
+    }
+
+    public function testCreateRequest(): void
+    {
+        $mock = $this->createMock(TransportInterface::class);
+        $result = $this->createMock(RequestInterface::class);
+        $mock->expects(self::once())
+            ->method('createRequest')
+            ->with('method', 'uri')
+            ->will(self::returnValue($result));
+
+        $transport = new RateLimitTransport($mock);
+        $request = $transport->createRequest('method', 'uri');
+        self::assertEquals($result, $request);
+    }
+
+    public function testCreateStream(): void
+    {
+        $mock = $this->createMock(TransportInterface::class);
+        $result = $this->createMock(StreamInterface::class);
+        $param = [];
+        $mock->expects(self::once())
+            ->method('createStream')
+            ->with($param)
+            ->will(self::returnValue($result));
+
+        $transport = new RateLimitTransport($mock);
+        $request = $transport->createStream($param);
+        self::assertEquals($result, $request);
+    }
+}


### PR DESCRIPTION
As requested in #30, I propose a documentation update to manage the API rate limit.

I added the implementation as optional too.

Feel free to edit the change :)